### PR TITLE
Add otel collector and auto instrumentation to fastapi in k8s

### DIFF
--- a/.azure-pipelines/basic_flows_ci.yml
+++ b/.azure-pipelines/basic_flows_ci.yml
@@ -197,7 +197,7 @@ stages:
                 --from-literal=connection-string=$(APPLICATIONINSIGHTS_CONNECTION_STRING)
 
       - task: AzureCLI@2
-        name: deploy_service
+        name: deploy_otel_service
         displayName: Deploy OTel collector to AKS
         continueOnError: false
         inputs: 

--- a/.azure-pipelines/basic_flows_ci.yml
+++ b/.azure-pipelines/basic_flows_ci.yml
@@ -172,6 +172,22 @@ stages:
             az aks get-credentials --resource-group $(RESOURCE_GROUP_NAME) --name $(AKS_NAME)
 
       - task: AzureCLI@2
+        name: deploy_service
+        displayName: Deploy OTel collector to AKS
+        continueOnError: false
+        inputs: 
+          azureSubscription: $(AZURE_RM_SVC_CONNECTION)
+          scriptType: bash
+          workingDirectory: $(System.DefaultWorkingDirectory)
+          scriptLocation: inlineScript
+          inlineScript: |
+            kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+            kubectl wait --for=condition=ready --timeout=60s -n cert-manager --all pods
+            kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.96.0/opentelemetry-operator.yaml
+            kubectl wait --for condition=established --timeout=60s crd/opentelemetrycollectors.opentelemetry.io
+            kubectl apply -f src/otel_collector/otel-collector.yaml
+
+      - task: AzureCLI@2
         name: secrets_create
         displayName: Create Secrets
         continueOnError: false

--- a/.azure-pipelines/basic_flows_ci.yml
+++ b/.azure-pipelines/basic_flows_ci.yml
@@ -172,6 +172,31 @@ stages:
             az aks get-credentials --resource-group $(RESOURCE_GROUP_NAME) --name $(AKS_NAME)
 
       - task: AzureCLI@2
+        name: secrets_create
+        displayName: Create Secrets
+        continueOnError: false
+        env:
+          AOAI_API_KEY: $(AOAI_API_KEY)
+          AOAI_BASE_ENDPOINT: $(AOAI_BASE_ENDPOINT)
+          APPLICATIONINSIGHTS_CONNECTION_STRING: $(APPLICATIONINSIGHTS_CONNECTION_STRING)
+        inputs: 
+          azureSubscription: $(AZURE_RM_SVC_CONNECTION)
+          scriptType: bash
+          workingDirectory: $(System.DefaultWorkingDirectory)
+          scriptLocation: inlineScript
+          inlineScript: |
+            kubectl delete secret aoai-secret -n basic-flow-app --ignore-not-found=true
+            kubectl create secret generic aoai-secret \
+                --from-literal=aoai-key=$(AOAI_API_KEY) \
+                --from-literal=aoai-endpoint=$(AOAI_BASE_ENDPOINT) \
+                --from-literal=aoai-deployment=gpt-35-turbo \
+                --from-literal=aoai-version=2023-07-01-preview \
+                -n basic-flow-app
+            kubectl delete secret appinsights-connection-secret --ignore-not-found=true
+            kubectl create secret appinsights-connection-secret \
+                --from-literal=connection-string=$(APPLICATIONINSIGHTS_CONNECTION_STRING)
+
+      - task: AzureCLI@2
         name: deploy_service
         displayName: Deploy OTel collector to AKS
         continueOnError: false
@@ -186,27 +211,6 @@ stages:
             kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.96.0/opentelemetry-operator.yaml
             kubectl wait --for condition=established --timeout=60s crd/opentelemetrycollectors.opentelemetry.io
             kubectl apply -f src/otel_collector/otel-collector.yaml
-
-      - task: AzureCLI@2
-        name: secrets_create
-        displayName: Create Secrets
-        continueOnError: false
-        env:
-          AOAI_API_KEY: $(AOAI_API_KEY)
-          AOAI_BASE_ENDPOINT: $(AOAI_BASE_ENDPOINT)
-        inputs: 
-          azureSubscription: $(AZURE_RM_SVC_CONNECTION)
-          scriptType: bash
-          workingDirectory: $(System.DefaultWorkingDirectory)
-          scriptLocation: inlineScript
-          inlineScript: |
-            kubectl delete secret aoai-secret -n basic-flow-app --ignore-not-found=true
-            kubectl create secret generic aoai-secret \
-                --from-literal=aoai-key=$(AOAI_API_KEY) \
-                --from-literal=aoai-endpoint=$(AOAI_BASE_ENDPOINT) \
-                --from-literal=aoai-deployment=gpt-35-turbo \
-                --from-literal=aoai-version=2023-07-01-preview \
-                -n basic-flow-app
     
       - task: AzureCLI@2
         name: deploy_service

--- a/.azure-pipelines/basic_flows_ci.yml
+++ b/.azure-pipelines/basic_flows_ci.yml
@@ -150,6 +150,7 @@ stages:
         inputs:
           command: buildAndPush
           repository: basic-flow-image
+          tags: latest
           buildContext: '$(Build.SourcesDirectory)' 
           dockerFile: '$(Build.SourcesDirectory)/src/basic_flow_fastapi_app/Dockerfile'
           containerRegistry: $(ACR_CONNECTION)

--- a/.azure-pipelines/basic_flows_ci.yml
+++ b/.azure-pipelines/basic_flows_ci.yml
@@ -193,7 +193,7 @@ stages:
                 --from-literal=aoai-version=2023-07-01-preview \
                 -n basic-flow-app
             kubectl delete secret appinsights-connection-secret --ignore-not-found=true
-            kubectl create secret appinsights-connection-secret \
+            kubectl create secret generic appinsights-connection-secret \
                 --from-literal=connection-string=$(APPLICATIONINSIGHTS_CONNECTION_STRING)
 
       - task: AzureCLI@2

--- a/.azure-pipelines/basic_flows_ci.yml
+++ b/.azure-pipelines/basic_flows_ci.yml
@@ -209,7 +209,7 @@ stages:
             kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
             kubectl wait --for=condition=ready --timeout=60s -n cert-manager --all pods
             kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.96.0/opentelemetry-operator.yaml
-            kubectl wait --for condition=established --timeout=60s crd/opentelemetrycollectors.opentelemetry.io
+            kubectl wait --for=condition=ready --timeout=60s -n opentelemetry-operator-system --all pods
             kubectl apply -f src/otel_collector/otel-collector.yaml
     
       - task: AzureCLI@2

--- a/src/basic_flow_fastapi_app/Dockerfile
+++ b/src/basic_flow_fastapi_app/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update -y && apt-get install -y sudo \
     && useradd -m -s /bin/bash $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && chown -R $USERNAME:$USERNAME /opt/miniconda
+    && chown -R $USERNAME:$USERNAME /opt/miniconda \
+    && chown -R $USERNAME:$USERNAME /azureml-envs/prompt-flow
 
 #Use the non-root user
 USER $USERNAME
@@ -28,13 +29,13 @@ RUN opentelemetry-bootstrap -a install
 
 # Copy FastAPI application
 COPY src/basic_flow_fastapi_app/main.py /home/$USERNAME/app/main.py
+# Copy run.sh
+COPY src/basic_flow_fastapi_app/run.sh /home/$USERNAME/app/run.sh
 
 COPY flows/function_basic_flow/standard /home/$USERNAME/app/function_basic_flow
 COPY flows/class_basic_flow/standard /home/$USERNAME/app/class_basic_flow
 COPY flows/yaml_basic_flow/standard /home/$USERNAME/app/yaml_basic_flow
 
 WORKDIR /home/$USERNAME/app
-
-COPY run.sh .
 
 CMD [ "./run.sh" ]

--- a/src/basic_flow_fastapi_app/Dockerfile
+++ b/src/basic_flow_fastapi_app/Dockerfile
@@ -23,6 +23,9 @@ COPY src/basic_flow_fastapi_app/requirements.txt .
 
 RUN pip install -r requirements.txt
 
+# Installs instrumentation libraries for OpenTelemetry
+RUN opentelemetry-bootstrap -a install
+
 # Copy FastAPI application
 COPY src/basic_flow_fastapi_app/main.py /home/$USERNAME/app/main.py
 
@@ -32,4 +35,6 @@ COPY flows/yaml_basic_flow/standard /home/$USERNAME/app/yaml_basic_flow
 
 WORKDIR /home/$USERNAME/app
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+COPY run.sh .
+
+CMD [ "./run.sh" ]

--- a/src/basic_flow_fastapi_app/deployment.yaml
+++ b/src/basic_flow_fastapi_app/deployment.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
       - name: basic-flow-app-container
         image: acrpromptpromptflow.azurecr.io/basic-flow-image:latest
+        imagePullPolicy: Always
         env:
         - name: AZURE_OPENAI_API_KEY
           valueFrom:

--- a/src/basic_flow_fastapi_app/main.py
+++ b/src/basic_flow_fastapi_app/main.py
@@ -1,4 +1,5 @@
 """The FastAPI application."""
+import logging
 import sys
 import pathlib
 import os
@@ -14,10 +15,14 @@ from function_basic_flow.extract_entities import extract_entity  # noqa: E402
 
 app = FastAPI()
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 @app.get("/class_basic_flow")
 def class_basic_flow(entity_type: str = None, text: str = None):
     """Return a message from the function_basic_flow endpoint."""
+    logger.info("class_basic_flow endpoint called.")
     if entity_type and text:
         connection = AzureOpenAIConnection(
             name="aoai",
@@ -49,6 +54,7 @@ def class_basic_flow(entity_type: str = None, text: str = None):
 @app.get("/function_basic_flow")
 def function_basic_flow(entity_type: str = None, text: str = None):
     """Return a message from the class_basic_flow endpoint."""
+    logger.info("function_basic_flow endpoint called.")
     if entity_type and text:
         result = extract_entity(entity_type=entity_type, text=text)
         return {"result": result}
@@ -61,6 +67,7 @@ def function_basic_flow(entity_type: str = None, text: str = None):
 @app.get("/yaml_basic_flow")
 def yaml_basic_flow(entity_type: str = None, text: str = None):
     """Return a message from the yaml_basic_flow endpoint."""
+    logger.info("yaml_basic_flow endpoint called.")
     if entity_type and text:
         connection = AzureOpenAIConnection(
             name="aoai",

--- a/src/basic_flow_fastapi_app/requirements.txt
+++ b/src/basic_flow_fastapi_app/requirements.txt
@@ -7,3 +7,7 @@ keyrings.alt
 # additional dependencies for application
 fastapi
 uvicorn
+# OpenTelemetry
+opentelemetry-distro==0.46b0
+opentelemetry-exporter-otlp==1.25.0
+opentelemetry-instrumentation-openai==0.21.5

--- a/src/basic_flow_fastapi_app/run.sh
+++ b/src/basic_flow_fastapi_app/run.sh
@@ -1,0 +1,16 @@
+PORT=${PORT:-8080}
+HOST=${HOST:-"0.0.0.0"}
+OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-"promptflow.fastapi"}
+OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-"http://otel-collector-collector.default.svc.cluster.local:4317"}
+
+export OTEL_RESOURCE_ATTRIBUTES="service.version=${OTEL_SERVICE_VERSION},service.instance.id=${OTEL_SERVICE_INSTANCE_ID}"
+
+export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+
+opentelemetry-instrument \
+    --traces_exporter otlp \
+    --metrics_exporter otlp \
+    --logs_exporter otlp \
+    --service_name "{$OTEL_SERVICE_NAME}" \
+    --exporter_otlp_endpoint "${OTEL_EXPORTER_OTLP_ENDPOINT}" \
+    uvicorn main:app --host "${HOST}" --port "${PORT}"

--- a/src/basic_flow_fastapi_app/run.sh
+++ b/src/basic_flow_fastapi_app/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 PORT=${PORT:-8080}
 HOST=${HOST:-"0.0.0.0"}
 OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-"promptflow.fastapi"}
@@ -14,6 +15,6 @@ opentelemetry-instrument \
     --traces_exporter otlp \
     --metrics_exporter otlp \
     --logs_exporter otlp \
-    --service_name "${$OTEL_SERVICE_NAME}" \
+    --service_name "${OTEL_SERVICE_NAME}" \
     --exporter_otlp_endpoint "${OTEL_EXPORTER_OTLP_ENDPOINT}" \
     uvicorn main:app --host "${HOST}" --port "${PORT}"

--- a/src/basic_flow_fastapi_app/run.sh
+++ b/src/basic_flow_fastapi_app/run.sh
@@ -1,6 +1,9 @@
 PORT=${PORT:-8080}
 HOST=${HOST:-"0.0.0.0"}
 OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-"promptflow.fastapi"}
+OTEL_SERVICE_VERSION=${OTEL_SERVICE_VERSION:-"0.0.1"}
+uuid=$(python -c "import uuid; print(uuid.uuid4())")
+OTEL_SERVICE_INSTANCE_ID=${OTEL_SERVICE_INSTANCE_ID:-${uuid}}
 OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-"http://otel-collector-collector.default.svc.cluster.local:4317"}
 
 export OTEL_RESOURCE_ATTRIBUTES="service.version=${OTEL_SERVICE_VERSION},service.instance.id=${OTEL_SERVICE_INSTANCE_ID}"

--- a/src/basic_flow_fastapi_app/run.sh
+++ b/src/basic_flow_fastapi_app/run.sh
@@ -17,4 +17,5 @@ opentelemetry-instrument \
     --logs_exporter otlp \
     --service_name "${OTEL_SERVICE_NAME}" \
     --exporter_otlp_endpoint "${OTEL_EXPORTER_OTLP_ENDPOINT}" \
+    --disabled_instrumentations sqlalchemy,sqlite3 \
     uvicorn main:app --host "${HOST}" --port "${PORT}"

--- a/src/basic_flow_fastapi_app/run.sh
+++ b/src/basic_flow_fastapi_app/run.sh
@@ -14,6 +14,6 @@ opentelemetry-instrument \
     --traces_exporter otlp \
     --metrics_exporter otlp \
     --logs_exporter otlp \
-    --service_name "{$OTEL_SERVICE_NAME}" \
+    --service_name "${$OTEL_SERVICE_NAME}" \
     --exporter_otlp_endpoint "${OTEL_EXPORTER_OTLP_ENDPOINT}" \
     uvicorn main:app --host "${HOST}" --port "${PORT}"

--- a/src/otel_collector/otel-collector.yaml
+++ b/src/otel_collector/otel-collector.yaml
@@ -1,0 +1,31 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.102.0
+  mode: deployment
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+
+    processors:
+      batch:
+
+    exporters:
+      azuremonitor: $APPLICATIONINSIGHTS_CONNECTION_STRING
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [azuremonitor]
+        metrics:
+          receivers: [otlp]
+          exporters: [azuremonitor]
+        logs:
+          receivers: [otlp]
+          exporters: [azuremonitor]

--- a/src/otel_collector/otel-collector.yaml
+++ b/src/otel_collector/otel-collector.yaml
@@ -10,7 +10,7 @@ spec:
       valueFrom:
         secretKeyRef:
           name: appinsights-connection-secret
-          key: connection_string
+          key: connection-string
   config: |
     receivers:
       otlp:

--- a/src/otel_collector/otel-collector.yaml
+++ b/src/otel_collector/otel-collector.yaml
@@ -9,8 +9,8 @@ spec:
     - name: APPLICATIONINSIGHTS_CONNECTION_STRING
       valueFrom:
         secretKeyRef:
-          name: aoai-secret
-          key: aoai-endpoint
+          name: appinsights-connection-secret
+          key: connection_string
   config: |
     receivers:
       otlp:

--- a/src/otel_collector/otel-collector.yaml
+++ b/src/otel_collector/otel-collector.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.102.0
   mode: deployment
+  env:
+    - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+      valueFrom:
+        secretKeyRef:
+          name: aoai-secret
+          key: aoai-endpoint
   config: |
     receivers:
       otlp:
@@ -16,7 +22,7 @@ spec:
       batch:
 
     exporters:
-      azuremonitor: $APPLICATIONINSIGHTS_CONNECTION_STRING
+      azuremonitor:
 
     service:
       pipelines:


### PR DESCRIPTION
## Description

This adds:

- auto instrumentation for fastapi
- ci steps to deploy
    - cert-manger
    - otel operator CRD
    - otel collector
- OpenTelemetry deployment yaml to collect telemetry and send to AppInsights

I verified that logs, traces and metrics were landing in AppInsights.

closes #88 

## A couple of notes:
1. With the current way that we deploy the fastapi app, it doesn't redeploy when we call kubectl apply. I believe this is due to having no changes in the yaml. Even though I set `imagePullPolicy` to `Always`, the redeployment is not triggered. I needed to delete the pod for it to come up with the latest version. 
2. Running this pipeline for the first time will fail since the namespace `basic-flow-app` needs to exist before creating the  secrets. We may want to modify this so the namespace gets created first. 


## To test:
1. connect to aks cluster `az aks get-credentials --resource-group $MY_RESOURCE_GROUP_NAME --name $MY_AKS_CLUSTER_NAME`
3. port-forward the service `kubectl port-forward svc/basic-flow-app-service 8080:8080 -n basic-flow-app`
4. go to browser and hit one of the endpoints `http://localhost:8080/class_basic_flow?entity_type=people%27s+full+name&text=The+novel+The+Great+Gatsby+was+written+by+F+Scott+Fitzgerald.`
5. Go to AppInsights instance and click the `Transaction search` tab. It will take around a minute for the telemetry to show up